### PR TITLE
Update gridclickertest.py

### DIFF
--- a/gridclickertest.py
+++ b/gridclickertest.py
@@ -94,7 +94,7 @@ while running:
             mouseX, mouseY = pygame.mouse.get_pos()
             gridX = mouseX // blocksize
             gridY = mouseY // blocksize
-            if event.type == pygame.MOUSEBUTTONDOWN:
+            if 0 <= gridX < wingGridwidth // blocksize and 0 <= gridY < windGridheight // blocksize:  # Boundary check
                 if event.button == LEFT:
                     if not left_clicked[gridY][gridX]:
                         if (gridX, gridY) in targets:
@@ -116,7 +116,6 @@ while running:
                         grid[gridY][gridX] = grey
                         print("Target square unmarked!")
 
-                
     # Render game
     screen.fill(grey)
     drawGrid()


### PR DESCRIPTION
To fix the IndexError: list index out of range issue that occurs when clicking outside the grid, you need to ensure that the calculated grid coordinates (gridX and gridY) are within the valid range before attempting to access the grid or update its state. You can achieve this by adding boundary checks right after calculating gridX and gridY from the mouse position.

Here's how you can modify your code to include these boundary checks:

if 0 <= gridX < wingGridwidth // blocksize and 0 <= gridY < windGridheight // blocksize:  # Boundary check

^ Line 97

- Courtesy of MR GPT